### PR TITLE
Added missing file path for owl.theme.default.min.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
 
     <!-- Owl Carousel -->
     <link rel="stylesheet" href="assets/css/plugin/owl.carousel.min.css" />
+    <link rel="stylesheet" href="assets/css/plugin/owl.theme.default.min.css">
 
     <!-- Magnific PopUp -->
     <link rel="stylesheet" href="assets/css/plugin/magnific-popup.css" />


### PR DESCRIPTION
I have added path for owl.theme.default.min.css which is required for Owl Carousel Plugin
```diff
+ <link rel="stylesheet" href="assets/css/plugin/owl.theme.default.min.css">

```